### PR TITLE
Fix fuzzing infinite loops in repeatMatch.Matches

### DIFF
--- a/matching/repeat.go
+++ b/matching/repeat.go
@@ -12,6 +12,18 @@ var greedy = regexp2.MustCompile(`(.+)\1+`, 0)
 var lazy = regexp2.MustCompile(`(.+?)\1+`, 0)
 var lazyAnchored = regexp2.MustCompile(`^(.+?)\1+$`, 0)
 
+func runeToStringIndex(index int, password string) int {
+	runes := 0
+	for i := range password {
+		if runes == index {
+			return i
+		}
+		runes++
+	}
+	//shouldn't really get here
+	return len(password)
+}
+
 func (repeatMatch) Matches(password string) []*match.Match {
 	var matches []*match.Match
 
@@ -44,8 +56,12 @@ func (repeatMatch) Matches(password string) []*match.Match {
 			rmatch = lazyMatch
 			baseToken = rmatch.GroupByNumber(1).String()
 		}
-		i := rmatch.Index
-		j := rmatch.Index + rmatch.Captures[0].Length - 1
+		// FindStringMatchStartingAt takes an index into the string (basically an offset
+		// into a byte array). rmatch indices will be rune offsets and so need to be converted
+		// to string offsets
+		i := runeToStringIndex(rmatch.Index, password)
+		j := runeToStringIndex(rmatch.Index+rmatch.Captures[0].Length-1, password)
+
 		// recursively match and score the base string
 		baseAnalysis := scoring.MostGuessableMatchSequence(
 			baseToken,

--- a/matching/repeat_test.go
+++ b/matching/repeat_test.go
@@ -1,10 +1,11 @@
 package matching
 
 import (
-	"github.com/test-go/testify/assert"
-	"github.com/trustelem/zxcvbn/match"
 	"strings"
 	"testing"
+
+	"github.com/test-go/testify/assert"
+	"github.com/trustelem/zxcvbn/match"
 )
 
 // removeRepeatBaseData removes extra data not needed for unit tests
@@ -168,4 +169,17 @@ func TestRepeatMatching(t *testing.T) {
 			RepeatCount: 4,
 		},
 	}, matches)
+}
+
+func TestCornerCases(t *testing.T) {
+	// cases found in fuzzing
+	testCases := []string{
+		"�\u007f\x00\x00Q",
+	}
+
+	r := repeatMatch{}
+
+	for _, password := range testCases {
+		_ = r.Matches(password)
+	}
 }


### PR DESCRIPTION
regexp2's FindStringMatchStartingAt takes a _string index_ as input.
The output matches refer to _rune array indices_. These need to be
converted to string indices to be passed safely into
FindStringMatchStartingAt in the loop.