### PR TITLE
Add initial feedback messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,4 +12,3 @@ This port aims to be fully compatible (i.e. give the same results for a given pa
 
 Current status:
 - this library should be 100% compatible (score, sequence and number of guesses) with [release 4.4.2](https://github.com/dropbox/zxcvbn/releases/tag/v4.4.2) of the coffeescript library.
-- feedback messages are missing

--- a/feedback/feedback.go
+++ b/feedback/feedback.go
@@ -1,0 +1,187 @@
+package feedback
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/trustelem/zxcvbn/match"
+	"github.com/trustelem/zxcvbn/scoring"
+)
+
+type Feedback struct {
+	Warning     string   `json:"warning"`
+	Suggestions []string `json:"suggestions"`
+}
+
+func GetFeedback(score int, sequence []*match.Match) *Feedback {
+	// starting feedback
+	if len(sequence) == 0 {
+		return defaultFeedback()
+	}
+
+	// no feedback if score is good or great.
+	if score > 2 {
+		return emptyFeedback()
+	}
+
+	// tie feedback to the longest match for longer sequences
+	longestMatch := sequence[0]
+	for _, match := range sequence[1:] {
+		if len(match.Token) > len(longestMatch.Token) {
+			longestMatch = match
+		}
+	}
+
+	feedback := getMatchFeedback(longestMatch, len(sequence) == 1)
+
+	extraFeedback := "Add another word or two. Uncommon words are better."
+
+	if feedback == nil {
+		return &Feedback{
+			Warning:     "",
+			Suggestions: []string{extraFeedback},
+		}
+	}
+
+	feedback.Suggestions = append([]string{extraFeedback}, feedback.Suggestions...)
+
+	return feedback
+}
+
+func getMatchFeedback(match *match.Match, isSoleMatch bool) *Feedback {
+	switch match.Pattern {
+	case "dictionary":
+		return getDictionaryMatchFeedback(match, isSoleMatch)
+	case "spatial":
+		var warning string
+		if match.Turns == 1 {
+			warning = "Straight rows of keys are easy to guess"
+		} else {
+			warning = "Short keyboard patterns are easy to guess"
+		}
+
+		return &Feedback{
+			Warning:     warning,
+			Suggestions: []string{"Use a longer keyboard pattern with more turns"},
+		}
+	case "repeat":
+		var warning string
+		if len(match.BaseToken) == 1 {
+			warning = "Repeats like \"aaa\" are easy to guess"
+		} else {
+			warning = "Repeats like \"abcabcabc\" are only slightly harder to guess than \"abc\""
+		}
+
+		return &Feedback{
+			Warning:     warning,
+			Suggestions: []string{"Avoid repeated words and characters"},
+		}
+	case "sequence":
+		return &Feedback{
+			Warning:     "Sequences like abc or 6543 are easy to guess",
+			Suggestions: []string{"Avoid sequences"},
+		}
+	case "regex":
+		if match.RegexName == "recent_year" {
+			return &Feedback{
+				Warning: "Recent years are easy to guess",
+				Suggestions: []string{
+					"Avoid recent years",
+					"Avoid years that are associated with you",
+				},
+			}
+		}
+
+		return emptyFeedback()
+	case "date":
+		return &Feedback{
+			Warning:     "Dates are often easy to guess",
+			Suggestions: []string{"Avoid dates and years that are associated with you"},
+		}
+	default:
+		return emptyFeedback()
+	}
+}
+
+func getDictionaryMatchFeedback(match *match.Match, isSoleMatch bool) *Feedback {
+	var warning string
+
+	if match.DictionaryName == "passwords" {
+		if isSoleMatch && !match.L33t && !match.Reversed {
+			if match.Rank <= 10 {
+				warning = "This is a top-10 common password"
+			} else if match.Rank <= 100 {
+				warning = "This is a top-100 common password"
+			} else {
+				warning = "This is a very common password"
+			}
+		}
+	} else if match.GuessesLog10 <= 4 {
+		warning = "This is similar to a commonly used password"
+	} else if match.DictionaryName == "english_wikipedia" {
+		if isSoleMatch {
+			warning = "A word by itself is easy to guess"
+		}
+	} else if stringInList(match.DictionaryName, []string{"surnames", "male_names", "female_names"}) {
+		if isSoleMatch {
+			warning = "Names and surnames by themselves are easy to guess"
+		} else {
+			warning = "Common names and surnames are easy to guess"
+		}
+	}
+
+	var suggestions []string
+	word := match.Token
+	if scoring.ReStartUpper.MatchString(word) {
+		suggestions = append(suggestions, "Capitalization doesn't help very much")
+	} else if scoring.ReAllUpper.MatchString(word) && strings.ToLower(word) != word {
+		suggestions = append(suggestions, "All-uppercase is almost as easy to guess as all-lowercase")
+	}
+
+	if match.Reversed && len(match.Token) == 4 {
+		suggestions = append(suggestions, "Reversed words aren't much harder to guess")
+	}
+	if match.L33t {
+		suggestions = append(suggestions, "Predictable substitutions like '@' instead of 'a' don't help very much")
+	}
+
+	return &Feedback{
+		Warning:     warning,
+		Suggestions: suggestions,
+	}
+}
+
+func stringInList(x string, list []string) bool {
+	for _, item := range list {
+		if item == x {
+			return true
+		}
+	}
+	return false
+}
+
+// ToString returns a string representation of the feedback
+func ToString(feedback *Feedback) string {
+	b, _ := json.Marshal(feedback)
+	return string(b)
+}
+
+func defaultFeedback() *Feedback {
+	return &Feedback{
+		Warning: "",
+		Suggestions: []string{
+			"Use a few words, avoid common phrases",
+			"No need for symbols, digits, or uppercase letters"},
+	}
+}
+
+// Why not just return nil? In practice it's much the same, but, there is a
+// difference between a nil and a empty slice. The main motivation for doing it
+// this way was when deserialising the test data, which would deserialise to
+// an empty slice, and not a nil slice.
+func emptyFeedback() *Feedback {
+	return &Feedback{
+		Warning:     "",
+		Suggestions: []string{},
+	}
+}

--- a/match/match.go
+++ b/match/match.go
@@ -43,7 +43,9 @@ type Match struct {
 	Day       int     `json:"day,omitempty"`
 	Separator string  `json:"separator,omitempty"`
 	Entropy   float64 `json:"entropy,omitempty"`
-	Guesses   float64 `json:"guesses,omitempty"`
+
+	Guesses      float64 `json:"guesses,omitempty"`
+	GuessesLog10 float64 `json:"guesses_log10,omitempty"`
 }
 
 type Matcher interface {

--- a/scoring/guesses.go
+++ b/scoring/guesses.go
@@ -91,9 +91,9 @@ func DictionaryGuesses(m *match.Match) float64 {
 	return float64(m.BaseGuesses) * float64(m.UppercaseVariations) * float64(m.L33tVariations) * float64(reversedVariations)
 }
 
-var reStartUpper = regexp.MustCompile(`^[A-Z][^A-Z]+$`)
+var ReStartUpper = regexp.MustCompile(`^[A-Z][^A-Z]+$`)
 var reEndUpper = regexp.MustCompile(`^[^A-Z]+[A-Z]$`)
-var reAllUpper = regexp.MustCompile(`^[^a-z]+$`)
+var ReAllUpper = regexp.MustCompile(`^[^a-z]+$`)
 var reAllLower = regexp.MustCompile(`^[^A-Z]+$`)
 
 func UppercaseVariations(w string) float64 {
@@ -103,9 +103,9 @@ func UppercaseVariations(w string) float64 {
 	// a capitalized word is the most common capitalization scheme,
 	// so it only doubles the search space (uncapitalized + capitalized).
 	// allcaps and end-capitalized are common enough too, underestimate as 2x factor to be safe.
-	if reStartUpper.MatchString(w) ||
+	if ReStartUpper.MatchString(w) ||
 		reEndUpper.MatchString(w) ||
-		reAllUpper.MatchString(w) {
+		ReAllUpper.MatchString(w) {
 		return 2
 	}
 	// otherwise calculate the number of ways to capitalize U+L uppercase+lowercase letters

--- a/scoring/scoring.go
+++ b/scoring/scoring.go
@@ -9,9 +9,10 @@ import (
 )
 
 type Result struct {
-	Password string
-	Guesses  float64
-	Sequence []*match.Match
+	Password     string
+	Guesses      float64
+	GuessesLog10 float64
+	Sequence     []*match.Match
 }
 
 // ------------------------------------------------------------------------------
@@ -228,6 +229,7 @@ func MostGuessableMatchSequence(password string, matches []*match.Match, exclude
 	// final result object
 	result.Password = password
 	result.Guesses = guesses
+	result.GuessesLog10 = math.Log10(guesses)
 	result.Sequence = optimalMatchSequence
 	return
 }

--- a/zxcvbn.go
+++ b/zxcvbn.go
@@ -1,19 +1,22 @@
 package zxcvbn
 
 import (
-	"github.com/trustelem/zxcvbn/match"
 	"time"
 	"unicode/utf8"
 
+	"github.com/trustelem/zxcvbn/feedback"
+	"github.com/trustelem/zxcvbn/match"
 	"github.com/trustelem/zxcvbn/matching"
 	"github.com/trustelem/zxcvbn/scoring"
 )
 
 type Result struct {
-	Guesses  float64
-	Sequence []*match.Match
-	Score    int
-	CalcTime float64
+	Guesses      float64
+	GuessesLog10 float64
+	Sequence     []*match.Match
+	Score        int
+	CalcTime     float64
+	Feedback     *feedback.Feedback
 }
 
 func PasswordStrength(password string, userInputs []string) Result {
@@ -31,6 +34,8 @@ func PasswordStrength(password string, userInputs []string) Result {
 	result.CalcTime = round(float64(calcTime)*time.Nanosecond.Seconds(), .5, 3)
 	result.Sequence = seq.Sequence
 	result.Guesses = seq.Guesses
+	result.Guesses = seq.GuessesLog10
 	result.Score = guessesToScore(seq.Guesses)
+	result.Feedback = feedback.GetFeedback(result.Score, result.Sequence)
 	return result
 }

--- a/zxcvbn_test.go
+++ b/zxcvbn_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/trustelem/zxcvbn/feedback"
 	"github.com/trustelem/zxcvbn/match"
 
 	"github.com/test-go/testify/assert"
@@ -15,10 +16,11 @@ import (
 
 func TestPasswordStrength(t *testing.T) {
 	var testdata []struct {
-		Password string         `json:"password"`
-		Guesses  float64        `json:"guesses"`
-		Score    int            `json:"score"`
-		Sequence []*match.Match `json:"sequence"`
+		Password string             `json:"password"`
+		Guesses  float64            `json:"guesses"`
+		Score    int                `json:"score"`
+		Sequence []*match.Match     `json:"sequence"`
+		Feedback *feedback.Feedback `json:"feedback"`
 	}
 
 	b, err := ioutil.ReadFile(filepath.Join("testdata", "output.json"))
@@ -65,6 +67,9 @@ func TestPasswordStrength(t *testing.T) {
 					if !assert.Equal(t, td.Sequence[j].Guesses, s.Sequence[j].Guesses, msg("guesses")) {
 						return
 					}
+					if !assert.InDelta(t, td.Sequence[j].GuessesLog10, s.Sequence[j].GuessesLog10, 0.000000000000001, msg("guesses_log10")) {
+						return
+					}
 				}
 			} else {
 				b, _ := json.Marshal(td.Sequence)
@@ -73,7 +78,9 @@ func TestPasswordStrength(t *testing.T) {
 					match.ToString(s.Sequence))
 				return
 			}
-			assert.Equal(t, td.Guesses, s.Guesses)
+			assert.Equal(t, td.Guesses, s.Guesses, "Wrong guesses")
+			assert.Equal(t, td.Feedback.Warning, s.Feedback.Warning, "Wrong feedback warning")
+			assert.Equal(t, td.Feedback.Suggestions, s.Feedback.Suggestions, "Wrong feedback suggestions")
 			assert.Equal(t, td.Score, s.Score, "Wrong score")
 		})
 	}


### PR DESCRIPTION
I've made a faithful re-implementation for `feedback.coffee` in Go. There are tests failing because the guesses values (and therefor guesses log 10 values) don't match.

The guesses log 10 value is used in calculating the feedback rule of "This is similar to a commonly used password", which is why this expectation is failing in the tests.

I wanted to open this PR now to get some feedback on the feedback and see if there were any suggestions on the incorrect guesses values.